### PR TITLE
Enable BSD function definitions and C99 POSIX compliance

### DIFF
--- a/src/physac.h
+++ b/src/physac.h
@@ -2,22 +2,22 @@
 *
 *   Physac v1.0 - 2D Physics library for videogames
 *
-*   DESCRIPTION: 
+*   DESCRIPTION:
 *
-*   Physac is a small 2D physics engine written in pure C. The engine uses a fixed time-step thread loop 
-*   to simluate physics. A physics step contains the following phases: get collision information, 
-*   apply dynamics, collision solving and position correction. It uses a very simple struct for physic 
+*   Physac is a small 2D physics engine written in pure C. The engine uses a fixed time-step thread loop
+*   to simluate physics. A physics step contains the following phases: get collision information,
+*   apply dynamics, collision solving and position correction. It uses a very simple struct for physic
 *   bodies with a position vector to be used in any 3D rendering API.
-* 
+*
 *   CONFIGURATION:
-*   
+*
 *   #define PHYSAC_IMPLEMENTATION
 *       Generates the implementation of the library into the included file.
-*       If not defined, the library is in header only mode and can be included in other headers 
+*       If not defined, the library is in header only mode and can be included in other headers
 *       or source files without problems. But only ONE file should hold the implementation.
 *
 *   #define PHYSAC_STATIC (defined by default)
-*       The generated implementation will stay private inside implementation file and all 
+*       The generated implementation will stay private inside implementation file and all
 *       internal symbols and functions will only be visible inside that file.
 *
 *   #define PHYSAC_NO_THREADS
@@ -30,7 +30,7 @@
 *       the user (check library implementation for further details).
 *
 *   #define PHYSAC_DEBUG
-*       Traces log messages when creating and destroying physics bodies and detects errors in physics 
+*       Traces log messages when creating and destroying physics bodies and detects errors in physics
 *       calculations and reference exceptions; it is useful for debug purposes
 *
 *   #define PHYSAC_MALLOC()
@@ -42,7 +42,7 @@
 *   NOTE: Physac requires multi-threading, when InitPhysics() a second thread is created to manage physics calculations.
 *
 *   Use the following code to compile (-static -lpthread):
-*   gcc -o $(NAME_PART).exe $(FILE_NAME) -s $(RAYLIB_DIR)\raylib\raylib_icon -static -lraylib -lpthread 
+*   gcc -o $(NAME_PART).exe $(FILE_NAME) -s $(RAYLIB_DIR)\raylib\raylib_icon -static -lraylib -lpthread
 *   -lglfw3 -lopengl32 -lgdi32 -lopenal32 -lwinmm -std=c99 -Wl,--subsystem,windows -Wl,-allow-multiple-definition
 *
 *   VERY THANKS TO:
@@ -250,6 +250,7 @@ PHYSACDEF void ClosePhysics(void);                                              
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
 #elif defined(__linux__) || defined(PLATFORM_WEB)
+    #define _DEFAULT_SOURCE         // Enables BSD function definitions and C99 POSIX compliance
     #include <sys/time.h>           // Required for: timespec
     #include <time.h>               // Required for: clock_gettime()
     #include <stdint.h>
@@ -404,7 +405,7 @@ PHYSACDEF PhysicsBody CreatePhysicsBodyRectangle(Vector2 pos, float width, float
         // Initialize new body with generic values
         newBody->id = newId;
         newBody->enabled = true;
-        newBody->position = pos;    
+        newBody->position = pos;
         newBody->velocity = (Vector2){ 0 };
         newBody->force = (Vector2){ 0 };
         newBody->angularVelocity = 0;
@@ -512,7 +513,7 @@ PHYSACDEF PhysicsBody CreatePhysicsBodyPolygon(Vector2 pos, float radius, int si
         // Initialize new body with generic values
         newBody->id = newId;
         newBody->enabled = true;
-        newBody->position = pos;    
+        newBody->position = pos;
         newBody->velocity = (Vector2){ 0 };
         newBody->force = (Vector2){ 0 };
         newBody->angularVelocity = 0;
@@ -1082,7 +1083,7 @@ static void PhysicsStep(void)
         PhysicsManifold manifold = contacts[i];
         if (manifold != NULL) DestroyPhysicsManifold(manifold);
     }
-    
+
     // Reset physics bodies grounded state
     for (int i = 0; i < physicsBodiesCount; i++)
     {
@@ -1208,7 +1209,7 @@ static PhysicsManifold CreatePhysicsManifold(PhysicsBody a, PhysicsBody b)
     }
 
     if (newId != -1)
-    {    
+    {
         // Initialize new manifold with generic values
         newManifold->id = newId;
         newManifold->bodyA = a;
@@ -1298,7 +1299,7 @@ static void SolvePhysicsManifold(PhysicsManifold manifold)
         } break;
         default: break;
     }
-    
+
     // Update physics body grounded state if normal direction is down and grounded state is not set yet in previous manifolds
     if (!manifold->bodyB->isGrounded) manifold->bodyB->isGrounded = (manifold->normal.y < 0);
 }
@@ -1395,7 +1396,7 @@ static void SolveCircleToPolygon(PhysicsManifold manifold)
     manifold->penetration = bodyA->shape.radius - separation;
 
     if (dot1 <= 0) // Closest to v1
-    {        
+    {
         if (DistSqr(center, v1) > bodyA->shape.radius*bodyA->shape.radius) return;
 
         manifold->contactsCount = 1;
@@ -1600,7 +1601,7 @@ static void IntegratePhysicsImpulses(PhysicsManifold manifold)
     // Early out and positional correct if both objects have infinite mass
     if (fabs(bodyA->inverseMass + bodyB->inverseMass) <= PHYSAC_EPSILON)
     {
-        bodyA->velocity = (Vector2){ 0 };        
+        bodyA->velocity = (Vector2){ 0 };
         bodyB->velocity = (Vector2){ 0 };
         return;
     }
@@ -1629,7 +1630,7 @@ static void IntegratePhysicsImpulses(PhysicsManifold manifold)
 
         // Calculate impulse scalar value
         float impulse = -(1.0f + manifold->restitution)*contactVelocity;
-        impulse /= inverseMassSum;                
+        impulse /= inverseMassSum;
         impulse /= (float)manifold->contactsCount;
 
         // Apply impulse to each physics body


### PR DESCRIPTION
This is just hypothetical. I think calls to <sys/time.h> require BSD function definitions. The old way was to define _BSD_SOURCE but it is included in the new way, _DEFAULT_SOURCE which also adds some POSIX stuff for c99.

You might look at raylib/src/external/dr_flac.h:682. where _BSD_SOURCE is defined. They should update, btw. One could do -D_DEFAULT_SOURCE -D_BSD_SOURCE to catch old systems too .My problem was not having either defined in raylib.
 [Here is my reference.](http://man7.org/linux/man-pages/man7/feature_test_macros.7.html)

Again, just something to look at. You might want to do it for portability outside of raylib where it has already been merged. Have a great day!