### PR TITLE
Add missing volatile declaration

### DIFF
--- a/src/physac.h
+++ b/src/physac.h
@@ -289,7 +289,7 @@ PHYSACDEF void ClosePhysics(void);                                              
 static pthread_t physicsThreadId;                           // Physics thread id
 #endif
 static unsigned int usedMemory = 0;                         // Total allocated dynamic memory
-static bool physicsThreadEnabled = false;                   // Physics thread enabled state
+static volatile bool physicsThreadEnabled = false;          // Physics thread enabled state
 static double baseTime = 0.0;                               // Offset time for MONOTONIC clock
 static double startTime = 0.0;                              // Start time in milliseconds
 static double deltaTime = 1.0/60.0/10.0 * 1000;             // Delta time used for physics steps, in milliseconds


### PR DESCRIPTION
`physicsThreadEnabled` was missing a `volatile` label causing the `pthread_join` to block indefinitely as the `while(physicsThreadEnabled)` loop was being optimised to `while(true)`.