### PR TITLE
Add ifndef to PHYSAC memory defines

### DIFF
--- a/src/physac.h
+++ b/src/physac.h
@@ -111,8 +111,13 @@
 #define     PHYSAC_PI                       3.14159265358979323846
 #define     PHYSAC_DEG2RAD                  (PHYSAC_PI/180.0f)
 
+#ifndef     PHYSAC_MALLOC
 #define     PHYSAC_MALLOC(size)             malloc(size)
+#endif      // PHYSAC_MALLOC
+
+#ifndef     PHYSAC_FREE
 #define     PHYSAC_FREE(ptr)                free(ptr)
+#endif      // PHYSAC_FREE
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition


### PR DESCRIPTION
If you are changing the definition of `PHYSAC_MALLOC`, you end up getting a warning. This makes it so that it only gets defined if it's not defined already.